### PR TITLE
docs: 画面仕様書作成コマンドとsync-with-ghフロー図を追加

### DIFF
--- a/.claude/commands/create-screen-spec.md
+++ b/.claude/commands/create-screen-spec.md
@@ -1,0 +1,10 @@
+# Create Screen Spec Command
+
+## Command
+`create-screen-spec`
+
+## Description
+docs/tasks/create-screen-spec.mdに記載されている手順に従って実行します。
+
+## Usage
+詳細な実行手順と説明については、`docs/tasks/create-screen-spec.md`を参照してください。

--- a/.cursor/rules/create-screen-spec.mdc
+++ b/.cursor/rules/create-screen-spec.mdc
@@ -1,0 +1,10 @@
+# Create Screen Spec Command
+
+## Command
+`create-screen-spec`
+
+## Description
+docs/tasks/create-screen-spec.mdに記載されている手順に従って実行します。
+
+## Usage
+詳細な実行手順と説明については、`docs/tasks/create-screen-spec.md`を参照してください。

--- a/docs/tasks/create-screen-spec.md
+++ b/docs/tasks/create-screen-spec.md
@@ -1,0 +1,103 @@
+# Create Screen Spec Command
+
+## Command
+`create-screen-spec`
+
+## Description
+docs/rules/screen-specs/のルールに従って画面仕様書を作成します。
+
+## Usage
+このコマンドを実行すると、画面仕様書の作成プロセスを支援します。
+
+## Prompt Template
+```
+画面仕様書を作成してください。
+
+対象画面：[画面名を指定]
+対象アプリ：[admin/customer/operation から選択]
+
+以下のルールに従って作成してください：
+- docs/rules/screen-specs/000_overview.md の全体構成を確認
+- docs/rules/screen-specs/001_creation.md の命名規則に従う
+- docs/rules/screen-specs/002_writing.md の記述ルールに従う
+- docs/rules/screen-specs/003_maintenance.md の品質基準を満たす
+- docs/screen-specs/TEMPLATE.md のテンプレートを使用
+```
+
+## 実行例
+
+### 1. 既存画面の確認
+```bash
+# 関連する既存仕様書を検索
+find docs/screen-specs -name "*.spec.md" | grep -i [画面名の一部]
+```
+
+### 2. ファイル名の決定
+```
+# 命名パターン
+{アプリ}_{機能}_{画面・要素名}_{日本語名}.spec.md
+
+# 例
+- customer_mypage_mypage-page_顧客_マイページ.spec.md
+- admin_customer-detail__affected-area-image-tab_管理者_顧客詳細__患部画像タブ.spec.md
+```
+
+### 3. テンプレートベースの作成
+```bash
+# テンプレートをコピーして新規作成
+cp docs/screen-specs/TEMPLATE.md docs/screen-specs/[新しいファイル名].spec.md
+```
+
+### 4. 内容の記述
+以下の要素を含めて記述：
+- 画面の基本情報（目的、対象ユーザー、前提条件）
+- URL情報
+- 主要機能一覧
+- 画面要素（表形式）
+- APIエンドポイント
+- 権限と表示制御
+- エラーハンドリング
+- 関連画面
+
+### 5. 品質チェック
+```bash
+# 品質チェック項目の確認
+- [ ] ファイル名が命名規則に従っている
+- [ ] 権限名が正式名称を使用している
+- [ ] 表が適切に作成されている（内容なしでも`----`表示）
+- [ ] 参照リンクが正しく設定されている
+- [ ] APIエンドポイントが明記されている
+```
+
+## 作成フロー
+```mermaid
+flowchart TD
+    A[画面仕様書作成開始] --> B[既存仕様書の確認]
+    B --> C[ファイル名の決定]
+    C --> D[テンプレートをコピー]
+    D --> E[基本情報を記入]
+    E --> F[画面要素を表形式で記述]
+    F --> G[API・権限情報を追加]
+    G --> H[品質チェック]
+    H --> I{チェックOK?}
+    I -->|Yes| J[README.mdを更新]
+    I -->|No| K[修正]
+    K --> H
+    J --> L[完了]
+```
+
+## 注意事項
+- 画面仕様書は**ソースコードから確認できる仕様のみ**記述する
+- スタイル（CSS）に関する記述は含めない
+- 権限名は必ず用語集で定義された正式名称を使用
+- 表は内容が存在しない場合でも作成し、`----`でブランク表示
+
+## 関連コマンド
+- `implementation` - 画面仕様書を基に実装を進める
+
+## 参考資料
+- [画面仕様書作成ルール概要](../../docs/rules/screen-specs/000_overview.md)
+- [新規作成ガイド](../../docs/rules/screen-specs/001_creation.md)
+- [記述・更新ガイド](../../docs/rules/screen-specs/002_writing.md)
+- [管理・品質ガイド](../../docs/rules/screen-specs/003_maintenance.md)
+- [テンプレート](../../docs/screen-specs/TEMPLATE.md)

--- a/docs/tasks/sync-with-gh-flow.md
+++ b/docs/tasks/sync-with-gh-flow.md
@@ -1,0 +1,121 @@
+# sync-with-gh コマンドフロー図
+
+AI agentが認識しやすいように構成されたsync-with-ghコマンドの作業フロー図です。
+
+```mermaid
+flowchart TD
+    %% スタート
+    START([sync-with-ghコマンド開始]) --> CHECK_STATUS
+
+    %% 変更の確認フェーズ
+    CHECK_STATUS[git status実行<br/>現在の変更を確認] --> HAS_CHANGES{変更が<br/>存在するか？}
+    
+    HAS_CHANGES -->|いいえ| NO_CHANGES[変更なし<br/>処理終了]
+    HAS_CHANGES -->|はい| ANALYZE_CHANGES
+    
+    %% 変更の分析フェーズ
+    ANALYZE_CHANGES[変更ファイルを分析<br/>関連性を評価] --> GROUP_CHANGES
+    
+    GROUP_CHANGES[変更をグループ化<br/>- 機能追加<br/>- バグ修正<br/>- ドキュメント更新<br/>- テスト追加<br/>- 依存関係更新] --> INIT_GROUPS
+    
+    %% グループ処理の初期化
+    INIT_GROUPS[グループリスト作成<br/>処理カウンター初期化] --> SELECT_GROUP
+    
+    %% グループ処理ループ
+    SELECT_GROUP{未処理の<br/>グループが<br/>あるか？} -->|いいえ| ALL_COMPLETE
+    SELECT_GROUP -->|はい| CHECKOUT_MAIN
+    
+    %% ブランチ作成フェーズ
+    CHECKOUT_MAIN[git checkout main<br/>mainブランチに移動] --> CREATE_BRANCH
+    
+    CREATE_BRANCH[git checkout -b branch-name<br/>新規ブランチ作成] --> BRANCH_CREATED{ブランチ作成<br/>成功？}
+    
+    BRANCH_CREATED -->|いいえ| BRANCH_ERROR[エラー処理<br/>ブランチ名を変更して再試行]
+    BRANCH_ERROR --> CREATE_BRANCH
+    BRANCH_CREATED -->|はい| STAGE_FILES
+    
+    %% ステージングフェーズ
+    STAGE_FILES[git add relevant-files<br/>関連ファイルをステージング] --> VERIFY_STAGING{ステージング<br/>成功？}
+    
+    VERIFY_STAGING -->|いいえ| STAGING_ERROR[ステージングエラー<br/>ファイルを確認]
+    STAGING_ERROR --> END_ERROR
+    VERIFY_STAGING -->|はい| CREATE_COMMIT
+    
+    %% コミットフェーズ
+    CREATE_COMMIT[git commit -m message<br/>Conventional Commits形式<br/>Claude署名を含む] --> COMMIT_SUCCESS{コミット<br/>成功？}
+    
+    COMMIT_SUCCESS -->|いいえ| COMMIT_ERROR[コミットエラー<br/>メッセージを確認]
+    COMMIT_ERROR --> END_ERROR
+    COMMIT_SUCCESS -->|はい| PUSH_BRANCH
+    
+    %% プッシュフェーズ
+    PUSH_BRANCH[git push -u origin branch-name<br/>リモートにプッシュ] --> PUSH_SUCCESS{プッシュ<br/>成功？}
+    
+    PUSH_SUCCESS -->|いいえ| PUSH_ERROR[プッシュエラー<br/>認証・接続を確認]
+    PUSH_ERROR --> END_ERROR
+    PUSH_SUCCESS -->|はい| CREATE_PR
+    
+    %% PR作成フェーズ
+    CREATE_PR[gh pr create<br/>--title タイトル<br/>--body 説明とテストプラン] --> PR_SUCCESS{PR作成<br/>成功？}
+    
+    PR_SUCCESS -->|いいえ| PR_ERROR[PR作成エラー<br/>権限・設定を確認]
+    PR_ERROR --> END_ERROR
+    PR_SUCCESS -->|はい| LOG_SUCCESS
+    
+    %% 成功記録と次のグループへ
+    LOG_SUCCESS[処理成功を記録<br/>PR URLを保存] --> UPDATE_COUNTER
+    UPDATE_COUNTER[処理済みカウンター更新] --> SELECT_GROUP
+    
+    %% 完了処理
+    ALL_COMPLETE[すべてのグループ処理完了<br/>作成したPRリストを表示] --> FINAL_CHECK
+    
+    FINAL_CHECK{すべて<br/>正常完了？} -->|はい| SUCCESS_END
+    FINAL_CHECK -->|いいえ| PARTIAL_SUCCESS
+    
+    SUCCESS_END([正常終了<br/>すべてのPR作成完了])
+    PARTIAL_SUCCESS([部分的成功<br/>一部のPRのみ作成])
+    NO_CHANGES([変更なしで終了])
+    END_ERROR([エラー終了])
+    
+    %% スタイル定義
+    classDef startEnd fill:#90EE90,stroke:#006400,stroke-width:3px
+    classDef error fill:#FFB6C1,stroke:#8B0000,stroke-width:2px
+    classDef decision fill:#87CEEB,stroke:#4682B4,stroke-width:2px
+    classDef process fill:#F0E68C,stroke:#DAA520,stroke-width:2px
+    
+    class START,SUCCESS_END,PARTIAL_SUCCESS,NO_CHANGES startEnd
+    class END_ERROR,BRANCH_ERROR,STAGING_ERROR,COMMIT_ERROR,PUSH_ERROR,PR_ERROR error
+    class HAS_CHANGES,SELECT_GROUP,BRANCH_CREATED,VERIFY_STAGING,COMMIT_SUCCESS,PUSH_SUCCESS,PR_SUCCESS,FINAL_CHECK decision
+```
+
+## AI Agent向け最適化のポイント
+
+このmermaid図は、AI agentが認識しやすいように以下の工夫をしています：
+
+### 1. 視覚的な区別
+- **開始・終了点**: 緑色（`startEnd`クラス）で明確に区別
+- **エラー処理**: 赤色（`error`クラス）で異常系を明示
+- **判断ポイント**: 青色（`decision`クラス）の菱形で条件分岐を表現
+- **処理ステップ**: 黄色（`process`クラス）で通常処理を表現
+
+### 2. 明確な処理フロー
+- 各ステップで実行する具体的なgitコマンドを記載
+- 判断基準を明確に記述（「成功？」「存在するか？」）
+- エラー時の処理パスを明示
+
+### 3. ループ構造の可視化
+- グループごとの処理がループになることを明確に表現
+- カウンター更新による進行管理を明示
+
+### 4. 状態管理
+- 処理の進行状況が追跡可能
+- 部分的成功と完全成功を区別
+
+### 5. エラーハンドリング
+- 各フェーズでのエラー処理を明示
+- リトライ可能な箇所（ブランチ作成）を表現
+
+この構成により、AI agentは：
+- どの段階で何を実行すべきか明確に理解できる
+- エラー時の対処方法が分かる
+- 全体の処理フローを俯瞰的に把握できる


### PR DESCRIPTION
## Summary
- create-screen-specコマンドを追加（画面仕様書作成支援）
- sync-with-ghコマンドのmermaidフロー図を作成
- Claude/Cursor向けの設定ファイルを生成

## 追加ファイル
- `docs/tasks/create-screen-spec.md` - 画面仕様書作成コマンド
- `docs/tasks/sync-with-gh-flow.md` - AI Agent向けフロー図
- `.claude/commands/create-screen-spec.md` - Claudeコマンド
- `.cursor/rules/create-screen-spec.mdc` - Cursorルール

## Test plan
- [x] create-screen-specコマンドが正しく定義されている
- [x] sync-with-ghフロー図が読みやすく構成されている
- [x] Claude/Cursor向け設定が適切に生成される

🤖 Generated with [Claude Code](https://claude.ai/code)