### PR TITLE
feat: スイング分析ページの追加

### DIFF
--- a/app/swing-analysis/SwingAnalysisPage.stories.tsx
+++ b/app/swing-analysis/SwingAnalysisPage.stories.tsx
@@ -1,0 +1,119 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import { expect } from 'storybook/test';
+import SwingAnalysisPage from './SwingAnalysisPage';
+
+const meta = {
+  title: 'Pages/SwingAnalysis/Page',
+  component: SwingAnalysisPage,
+  parameters: {
+    layout: 'fullscreen',
+    nextjs: {
+      appDirectory: true,
+      navigation: {
+        pathname: '/swing-analysis',
+      },
+    },
+  },
+  tags: ['autodocs'],
+} satisfies Meta<typeof SwingAnalysisPage>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  play: async ({ canvas }) => {
+    // ページ全体のレンダリング確認
+    const heading = canvas.getByRole('heading', { name: 'スイング分析' });
+    await expect(heading).toBeInTheDocument();
+    
+    // ページの説明文
+    const description = canvas.getByText('あなたのスイング動画をAIが詳細分析します');
+    await expect(description).toBeInTheDocument();
+  },
+};
+
+export const PageStructure: Story = {
+  play: async ({ canvas }) => {
+    // グラデーション背景の確認
+    const pageContainer = canvas.getByRole('heading', { name: 'スイング分析' }).closest('.min-h-screen');
+    await expect(pageContainer).toHaveClass('bg-gradient-to-br', 'from-blue-50', 'to-purple-50');
+    
+    // コンテンツの最大幅確認
+    const contentContainer = canvas.getByRole('heading', { name: 'スイング分析' }).closest('.max-w-6xl');
+    await expect(contentContainer).toBeInTheDocument();
+  },
+};
+
+export const VideoUploadSection: Story = {
+  play: async ({ canvas }) => {
+    // 動画アップロードカードの確認
+    const uploadCard = canvas.getByText('スイング動画アップロード').closest('[data-slot="card"]');
+    await expect(uploadCard).toBeInTheDocument();
+    
+    // アップロードエリアの確認
+    const uploadArea = canvas.getByText('動画をアップロード');
+    await expect(uploadArea).toBeInTheDocument();
+  },
+};
+
+export const NavigationFlow: Story = {
+  play: async ({ canvas }) => {
+    // ホームへ戻るボタンの確認
+    const homeButton = canvas.getByRole('button', { name: 'ホームに戻る' });
+    await expect(homeButton).toBeInTheDocument();
+    
+    // 動画管理ページへのリンク
+    const videoManagementLink = canvas.getByText('動画管理ページへ');
+    await expect(videoManagementLink).toBeInTheDocument();
+  },
+};
+
+export const ResponsiveDesign: Story = {
+  parameters: {
+    viewport: {
+      defaultViewport: 'mobile1',
+    },
+  },
+  play: async ({ canvas }) => {
+    // モバイルでの表示確認
+    const heading = canvas.getByRole('heading', { name: 'スイング分析' });
+    await expect(heading).toBeInTheDocument();
+    
+    // グリッドレイアウトの確認
+    const gridContainer = canvas.getByText('スイング動画アップロード').closest('.grid');
+    await expect(gridContainer).toBeInTheDocument();
+  },
+};
+
+export const EmptyState: Story = {
+  play: async ({ canvas }) => {
+    // 初期状態（動画未アップロード）の確認
+    const uploadPrompt = canvas.getByText('動画をアップロード');
+    await expect(uploadPrompt).toBeInTheDocument();
+    
+    // AI分析開始ボタンが存在しないことを確認
+    const analyzeButton = canvas.queryByRole('button', { name: 'AI分析開始' });
+    await expect(analyzeButton).not.toBeInTheDocument();
+  },
+};
+
+export const FullPageIntegration: Story = {
+  play: async ({ canvas }) => {
+    // ページ全体の統合テスト
+    // ヘッダー
+    const heading = canvas.getByRole('heading', { name: 'スイング分析' });
+    await expect(heading).toBeInTheDocument();
+    
+    // 説明文
+    const description = canvas.getByText('あなたのスイング動画をAIが詳細分析します');
+    await expect(description).toBeInTheDocument();
+    
+    // アップロードカード
+    const uploadCard = canvas.getByText('スイング動画アップロード');
+    await expect(uploadCard).toBeInTheDocument();
+    
+    // フッター部分のボタン
+    const homeButton = canvas.getByRole('button', { name: 'ホームに戻る' });
+    await expect(homeButton).toBeInTheDocument();
+  },
+};

--- a/app/swing-analysis/SwingAnalysisPage.tsx
+++ b/app/swing-analysis/SwingAnalysisPage.tsx
@@ -1,0 +1,7 @@
+'use client';
+
+import SwingAnalysis from './_components/SwingAnalysis';
+
+export default function SwingAnalysisPage() {
+  return <SwingAnalysis />;
+}

--- a/app/swing-analysis/_components/SwingAnalysis.stories.tsx
+++ b/app/swing-analysis/_components/SwingAnalysis.stories.tsx
@@ -1,0 +1,115 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import { expect, userEvent } from 'storybook/test';
+import SwingAnalysis from './SwingAnalysis';
+
+const meta = {
+  title: 'Pages/SwingAnalysis/SwingAnalysis',
+  component: SwingAnalysis,
+  parameters: {
+    layout: 'fullscreen',
+    nextjs: {
+      appDirectory: true,
+      navigation: {
+        pathname: '/swing-analysis',
+      },
+    },
+  },
+  tags: ['autodocs'],
+} satisfies Meta<typeof SwingAnalysis>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  play: async ({ canvas }) => {
+    // ヘッダーの確認
+    const heading = canvas.getByRole('heading', { name: 'スイング分析' });
+    await expect(heading).toBeInTheDocument();
+    
+    // 動画アップロード領域の確認
+    const uploadText = canvas.getByText('動画をアップロード');
+    await expect(uploadText).toBeInTheDocument();
+  },
+};
+
+export const BackButton: Story = {
+  play: async ({ canvas }) => {
+    // 戻るボタンの確認
+    const backButton = canvas.getByRole('button', { name: 'ホームに戻る' });
+    await expect(backButton).toBeInTheDocument();
+    await expect(backButton).toBeEnabled();
+  },
+};
+
+export const FileUploadArea: Story = {
+  play: async ({ canvas }) => {
+    // アップロードエリアの存在確認
+    const uploadArea = canvas.getByText('動画をアップロード').closest('div');
+    await expect(uploadArea).toBeInTheDocument();
+    
+    // ファイル形式の説明
+    const formatText = canvas.getByText(/MP4, MOV, AVI形式対応/);
+    await expect(formatText).toBeInTheDocument();
+    
+    // サイズ制限の説明
+    const sizeText = canvas.getByText(/最大100MB/);
+    await expect(sizeText).toBeInTheDocument();
+  },
+};
+
+export const CardStructure: Story = {
+  play: async ({ canvas }) => {
+    // カードヘッダーの確認
+    const cardTitle = canvas.getByText('スイング動画アップロード');
+    await expect(cardTitle).toBeInTheDocument();
+    
+    const cardDescription = canvas.getByText(/正面または側面からのスイング動画をアップロードしてください/);
+    await expect(cardDescription).toBeInTheDocument();
+  },
+};
+
+export const UIComponents: Story = {
+  play: async ({ canvas }) => {
+    // Buttonコンポーネントの確認
+    const button = canvas.getByRole('button', { name: 'ホームに戻る' });
+    await expect(button).toHaveAttribute('data-slot', 'button');
+    
+    // Cardコンポーネントの確認
+    const cardTitle = canvas.getByText('スイング動画アップロード');
+    const card = cardTitle.closest('[data-slot="card"]');
+    await expect(card).toBeInTheDocument();
+  },
+};
+
+export const ResponsiveLayout: Story = {
+  parameters: {
+    viewport: {
+      defaultViewport: 'mobile1',
+    },
+  },
+  play: async ({ canvas }) => {
+    // モバイルビューでの表示確認
+    const heading = canvas.getByRole('heading', { name: 'スイング分析' });
+    await expect(heading).toBeInTheDocument();
+    
+    // カードが存在することを確認
+    const card = canvas.getByText('スイング動画アップロード').closest('[data-slot="card"]');
+    await expect(card).toBeInTheDocument();
+  },
+};
+
+export const VideoManagementLink: Story = {
+  play: async ({ canvas }) => {
+    // 動画管理ページへのリンクを確認
+    const managementLink = canvas.getByText('動画管理ページへ');
+    await expect(managementLink).toBeInTheDocument();
+  },
+};
+
+export const ProNameDisplay: Story = {
+  play: async ({ canvas }) => {
+    // デフォルトのプロ名（田中 太郎）が表示されることを確認
+    const defaultProName = canvas.getByText(/田中 太郎/);
+    await expect(defaultProName).toBeInTheDocument();
+  },
+};

--- a/app/swing-analysis/_components/SwingAnalysis.tsx
+++ b/app/swing-analysis/_components/SwingAnalysis.tsx
@@ -52,15 +52,9 @@ interface SwingAnalysisResult {
   strengths: string[];
 }
 
-interface SwingAnalysisProps {
-  onBack: () => void;
-  matchedProName?: string;
-}
 
-export default function SwingAnalysis({
-  onBack,
-  matchedProName = '田中 太郎',
-}: SwingAnalysisProps) {
+export default function SwingAnalysis() {
+  const matchedProName = '田中 太郎';
   const router = useRouter();
   const [uploadedVideo, setUploadedVideo] = useState<File | null>(null);
   const [videoUrl, setVideoUrl] = useState<string>('');
@@ -113,7 +107,7 @@ export default function SwingAnalysis({
     if (!uploadedVideo) return;
     
     try {
-      const videoId = await videoStorage.saveVideo(uploadedVideo);
+      await videoStorage.saveVideo(uploadedVideo);
       await loadSavedVideos();
       alert('動画が保存されました');
     } catch (error) {
@@ -546,8 +540,8 @@ export default function SwingAnalysis({
         )}
 
         <div className="flex justify-center gap-4">
-          <Button onClick={onBack} variant="outline">
-            診断結果に戻る
+          <Button onClick={() => router.push('/')} variant="outline">
+            ホームに戻る
           </Button>
           {analysisResult && (
             <Button className="bg-green-600 hover:bg-green-700">

--- a/app/swing-analysis/_components/index.ts
+++ b/app/swing-analysis/_components/index.ts
@@ -1,0 +1,1 @@
+export { default as SwingAnalysis } from './SwingAnalysis';

--- a/app/swing-analysis/page.stories.tsx
+++ b/app/swing-analysis/page.stories.tsx
@@ -1,0 +1,85 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import { expect } from 'storybook/test';
+import Page from './page';
+
+const meta = {
+  title: 'Pages/SwingAnalysis/ServerPage',
+  component: Page,
+  parameters: {
+    layout: 'fullscreen',
+    nextjs: {
+      appDirectory: true,
+      navigation: {
+        pathname: '/swing-analysis',
+      },
+    },
+  },
+  tags: ['autodocs'],
+} satisfies Meta<typeof Page>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  play: async ({ canvas }) => {
+    // サーバーコンポーネントのレンダリング確認
+    const heading = canvas.getByRole('heading', { name: 'スイング分析' });
+    await expect(heading).toBeInTheDocument();
+  },
+};
+
+export const MetadataRendering: Story = {
+  play: async ({ canvas }) => {
+    // ページがレンダリングされることを確認
+    // メタデータはStorybook内では直接テストできないが、
+    // ページコンポーネントが正しくレンダリングされることを確認
+    const pageContent = canvas.getByText('あなたのスイング動画をAIが詳細分析します');
+    await expect(pageContent).toBeInTheDocument();
+  },
+};
+
+export const ClientComponentIntegration: Story = {
+  play: async ({ canvas }) => {
+    // サーバーコンポーネントがクライアントコンポーネントを
+    // 正しくレンダリングすることを確認
+    const uploadCard = canvas.getByText('スイング動画アップロード');
+    await expect(uploadCard).toBeInTheDocument();
+    
+    const homeButton = canvas.getByRole('button', { name: 'ホームに戻る' });
+    await expect(homeButton).toBeInTheDocument();
+  },
+};
+
+export const FullPageLoad: Story = {
+  play: async ({ canvas }) => {
+    // ページ全体が正しくロードされることを確認
+    // ヘッダー部分
+    const header = canvas.getByRole('heading', { level: 1 });
+    await expect(header).toHaveTextContent('スイング分析');
+    
+    // 説明文
+    const description = canvas.getByText(/AIが詳細分析/);
+    await expect(description).toBeInTheDocument();
+    
+    // メインコンテンツ
+    const mainContent = canvas.getByText('動画をアップロード');
+    await expect(mainContent).toBeInTheDocument();
+  },
+};
+
+export const PageAccessibility: Story = {
+  play: async ({ canvas }) => {
+    // アクセシビリティの基本的な確認
+    // ランドマークの確認
+    const main = canvas.getByRole('main');
+    await expect(main).toBeInTheDocument();
+    
+    // ヘッディング階層の確認
+    const h1 = canvas.getByRole('heading', { level: 1 });
+    await expect(h1).toBeInTheDocument();
+    
+    // インタラクティブ要素の確認
+    const buttons = canvas.getAllByRole('button');
+    await expect(buttons.length).toBeGreaterThan(0);
+  },
+};

--- a/app/swing-analysis/page.tsx
+++ b/app/swing-analysis/page.tsx
@@ -1,0 +1,11 @@
+import type { Metadata } from 'next';
+import SwingAnalysisPage from './SwingAnalysisPage';
+
+export const metadata: Metadata = {
+  title: 'スイング分析 | Golfitter',
+  description: 'AIによるゴルフスイング分析',
+};
+
+export default function Page() {
+  return <SwingAnalysisPage />;
+}


### PR DESCRIPTION
## 概要
スイング分析機能を独立したページとして実装しました。

## 変更内容
- ✅ `app/swing-analysis/`に新しいスイング分析ページを追加
- ✅ コンポーネントをページ固有のディレクトリに移動
- ✅ Storybookテストを追加

## 機能
- 動画のアップロードとプレビュー
- AIによるスイング解析
- 解析結果の表示（スコア、改善点、アドバイス）

## テストプラン
- [ ] `/swing-analysis`ページが正常に表示されることを確認
- [ ] 動画のアップロードが機能することを確認
- [ ] 解析結果が正しく表示されることを確認
- [ ] Storybookでコンポーネントの動作を確認

🤖 Generated with [Claude Code](https://claude.ai/code)